### PR TITLE
Fix for the documentation (and a minor typo in code) to have better readability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ About
 -----
 C implementation of a basic state design pattern
 
-Each state of the machine is associated to a function. The function must take a void * and return an int. The return value is use for transition between state (functions).
+Each state of the machine is associated to a function. The function must take a `void *` and return an `int`. The return value is use for transition between state (functions).
 
 Author
 ------
@@ -17,25 +17,44 @@ Julien Allali (allali.julien@gmail.com)
 
 Compilation
 -----------
-compilation of the project is done using cmake.
+Compilation of the project is done using `cmake`.
 
-First create a build directory:
-> mkdir build
-then run cmake from this directory:
-> cd build
-> cmake ..
-and compile with make:
-> make
-> make doc
-optionaly, you can install the library using 
-> make install
-the install directory can be specified when calling cmake:
-> cmake -DCMAKE_INSTALL_PREFIX:PATH=$HOME/usr
+First create a `build` directory:
+
+```sh
+mkdir build
+```
+
+then run `cmake` from this directory:
+
+```sh
+cd build
+cmake ..
+```
+
+and compile with `make`:
+
+```sh
+make
+make doc
+```
+
+optionaly, you can install the library using:
+
+```sh
+make install
+```
+
+the install directory can be specified when calling `cmake`:
+
+```sh
+cmake -DCMAKE_INSTALL_PREFIX:PATH=$HOME/usr
+```
 
 Example
 -------
-You will find examples into the demos directory
+You will find examples into the `demos` directory
 
 API
 ---
-see [the documentation here](@ref state.h)
+See [the documentation here](@ref state.h)

--- a/src/state.c
+++ b/src/state.c
@@ -3,7 +3,7 @@
 
 /* ------------------------------------------------- *
  *
- * this code is under LIT Licence
+ * this code is under MIT Licence
  *
  * author: Julien Allali (allali.julien@gmail.com)
  *


### PR DESCRIPTION
This Pull Request includes two fixes:
- the `README.md` file has seen some modifications to get better code reading (tested with `make doc`, and confirmed that the fix was compatible with Doxygen's way of using this markdown file)
- the `state.c` file has seen a minor modification: in the header of this file, there was a mention to the `LIT License` but this code is licensed under the `MIT License`. It was a minor typo but as the LIT License seems to exist, it could be a problem if someone decided to reuse this code.